### PR TITLE
Bump quill-delta to ^4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## V4.0.0
+
+#### Breaking Changes
+- Update to quill-delta ^4
+
 ## v3.0.0
 
 #### Breaking Changes

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/ottypes/rich-text",
   "main": "index.js",
   "dependencies": {
-    "quill-delta": "^3.2.0"
+    "quill-delta": "^4.1.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
Noticed quill-delta has 4 published, figure it would be nice for consumers using rich-text to get the latest version.