### PR TITLE
Bump `quill-delta`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## v4.0.0
+
+#### Breaking Changes
+These were never documented as officially supported but to be safe we are doing a major version bump.
+
+- No longer works in IE8 as there is function called delete and IE8 treats that as a reserved identifier
+- The source structure has changed so those utilizing NPM's ability to import from arbitrary directories ex. import
+  DeltaOp from 'quill-delta/lib/op' will have to update their imports
+
 ## v3.0.0
 
 #### Breaking Changes

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "rich-text",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "description": "OT type for rich text",
   "author": "Jason Chen <jhchen7@gmail.com>",
   "homepage": "https://github.com/ottypes/rich-text",
   "main": "index.js",
   "dependencies": {
-    "quill-delta": "^3.2.0"
+    "quill-delta": "^4.2.1"
   },
   "devDependencies": {
     "chai": "^3.5.0",
@@ -19,7 +19,7 @@
   },
   "license": "MIT",
   "scripts": {
-    "test": "mocha test/fuzzer.js"
+    "test": "mocha test/fuzzer.js --timeout 5000"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This change bumps the version of `quill-delta`, which this package
wraps. `quill-delta` has been through a major version change, so this
change also bumps the package version through a major version change to
be safe.