### PR TITLE
Make sure delta is a Delta object on transformCursor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
-node_js: '6'
+node_js: '12'
 script:
   - npm test

--- a/lib/type.js
+++ b/lib/type.js
@@ -37,6 +37,7 @@ module.exports = {
     },
 
     transformCursor: function(cursor, delta, isOwnOp) {
+      delta = new Delta(delta);
       return delta.transformPosition(cursor, !isOwnOp);
     },
 

--- a/test/cursors.js
+++ b/test/cursors.js
@@ -1,0 +1,15 @@
+const { expect } = require("chai");
+
+const { type, Delta } = require("../lib/type");
+
+describe("cursors", function () {
+  it("transforms cursor on deltas", function () {
+    const op = new Delta().retain(1).insert("hi");
+    expect(type.transformCursor(2, op)).to.eql(4);
+  });
+
+  it("transforms cursor on objects", function () {
+    const op = [{ retain: 1 }, { insert: "hi" }];
+    expect(type.transformCursor(2, op)).to.eql(4);
+  });
+});


### PR DESCRIPTION
Hey! 

I'm trying to implement presence in `ot-json1`, and most of the time subtypes are dealt unserialized. This works fine, until we try to use `transformCursor`. It can only deal with `Delta` objects.

This PR make sure the delta params is a Delta object.