### PR TITLE
✨ Add support for `invertWithDoc`

### DIFF
--- a/lib/type.js
+++ b/lib/type.js
@@ -66,5 +66,11 @@ module.exports = {
         length: end - start,
       });
     },
+
+    invertWithDoc: function(delta, doc) {
+      delta = new Delta(delta);
+      doc = new Delta(doc);
+      return delta.invert(doc);
+    }
   }
 };


### PR DESCRIPTION
This change adds support for the [optional, but recommended][1]
`invertWithDoc(op, doc) -> op'` method, which is already implemented as
[`Delta.invert()`][2]

[1]: https://github.com/ottypes/docs#optional-properties
[2]: https://github.com/quilljs/delta/#invert